### PR TITLE
Make Ingress comply to k8s API v1.19

### DIFF
--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -2,7 +2,7 @@
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
   {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -32,7 +32,7 @@ spec:
       http:
         paths:
           {{- range .paths }}
-          - path: {{ .path }}
+          - path: {{ . }}
             pathType: Prefix
             backend:
               service:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "invoiceninja.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 {{- else -}}
 apiVersion: extensions/v1beta1
 {{- end }}
@@ -33,9 +33,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port: 
+                  number: {{ $svcPort }}
           {{- end }}
     {{- end }}
   {{- end }}


### PR DESCRIPTION
Changes successfully tested:

```
$ git clone -b patch-1 https://github.com/wagnst/invoiceninja-helm
Cloning into 'invoiceninja-helm'...

$ cd invoiceninja-helm

$ helm dependency update
Getting updates for unmanaged Helm repositories...
...Successfully got an update from the "https://charts.bitnami.com/bitnami" chart repository
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "stable" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 1 charts
Downloading mysql from repo https://charts.bitnami.com/bitnami
Deleting outdated charts

$ helm upgrade --install invoiceninja-helm . --namespace invoiceninja -f ../values.yaml
Release "invoiceninja-helm" does not exist. Installing it now.
NAME: invoiceninja-helm
LAST DEPLOYED: Sun Mar 14 13:44:38 2021
NAMESPACE: invoiceninja
STATUS: deployed
REVISION: 1
NOTES:
1. Get the application URL by running these commands:
  https://xxx/
Cleaning up file based variables 00:02
Job succeeded
````